### PR TITLE
Add check for escaped keys and handle them correctly

### DIFF
--- a/lua/libmodal/collections/ParseTable.lua
+++ b/lua/libmodal/collections/ParseTable.lua
@@ -39,6 +39,22 @@ local function get(parse_table, lhs_reversed_bytes)
 		return parse_table
 	end
 
+	local out = k
+
+	if type(k) == "string" then
+		for index = 1, #k do
+			local character = k:byte(index)
+
+			if index == 1 then
+				out = character
+			else
+				table.insert(lhs_reversed_bytes, 1, character)
+			end
+		end
+	end
+
+	k = out
+
 	--[[ Parse the `k`. ]]
 
 	-- make sure the dicitonary has a key for that value.


### PR DESCRIPTION
I noticed that I was unable to bind keys such as `<Left>` and `<Right>` and after looking into it, I believe that I understand what is going on. When building the parse tables from a binding such as "das" libmodal will create a table like
```lua
["d"] = {
    ["a"] = {
        ["s"] = "command"
    }
}
```

From the neovim documentation for [`getchar`](https://neovim.io/doc/user/builtin.html#getchar()) we see that
> Without [expr] and when [expr] is 0 a whole character or
special key is returned.  If it is a single character, the
result is a Number.  Use nr2char() to convert it to a String.
Otherwise a String is returned with the encoded character.
For a special key it's a String with a sequence of bytes
starting with 0x80 (decimal: 128).  This is the same value as
the String "\<Key>", e.g., "\<Left>".  The returned value is
also a String when a modifier (shift, control, alt) was used
that is not included in the character.

But the code using the output of `getchar` never handles the case where it is a string.

So if we tried mapping a key like `<Left>` it results in a table that looks like
```lua
[128] = {
     ["k"] = {
          ["l"] = "command"
     }
}
```
But we are indexing the parse table with the string `"<80>kl"`, which is obviously `nil`.

In my proposed solution I split the string into it's individual bytes so they find the correct entries. You can then define you bindings like this
```lua
local function c(binding)
    return vim.api.nvim_replace_termcodes(binding, true, true, true)
end

require('libmodal').mode.enter('Test', {
    [c('<Left>')] = function()
        print("left")
    end,
    [c('d<Right>')] = function()
        print("d followed by right")
    end,
})
```

While this works very well, I am not super happy with the code and with the fact that the user has to manually call `nvim_replace_termcodes`. If you have any suggestions on how to improve please let me know.