### PR TITLE
fix(mode): incompatible with vim.v.count

### DIFF
--- a/doc/libmodal.txt
+++ b/doc/libmodal.txt
@@ -127,14 +127,6 @@ VARIABLES                                               *libmodal-usage-variable
 		})
 <
 
-                                                            *libmodal.Mode.count1*
-`Mode`.count1
-
-	The |v:count1| equivalent of |libmodal.Mode.count|.
-
-	Type: ~
-		|libmodal-Var| of |lua-number|
-
                                                               *libmodal.Mode.exit*
 `Mode`.exit
 
@@ -211,7 +203,7 @@ FUNCTIONS                                               *libmodal-usage-function
 			          -- You can also use lua functions
 			          zfc = function() vim.api.nvim_command 'tabnew' end
 			      }
-< >vim
+<>vim
 			    let s:modeInstruction = {
 			        'zf': 'split',
 			        'zfo': 'vsplit',
@@ -225,8 +217,13 @@ FUNCTIONS                                               *libmodal-usage-function
 			  that |getchar()| completes. The user input is received through
 			  `g:{name}ModeInput` (see above).
 
-			- |v:count| and |v:count1| are provided through `g:{name}ModeCount`
-			  and `g:{name}ModeCount1` respectively.
+			- |v:count| is provided through `g:{name}ModeCount`. For |v:count1|
+			  do: >lua
+				local count1 = math.max(1, count) -- lua
+<>vim
+				let count1 = max(1, count) " vimscript
+<
+
 
 			*Error	you cannot pass a funcref to Lua from Vimscript!
 			      	- If you want to use a |funcref()| for {instruction}, it

--- a/doc/libmodal.txt
+++ b/doc/libmodal.txt
@@ -161,6 +161,9 @@ FUNCTIONS                                               *libmodal-usage-function
 			  that |getchar()| completes. The user input is received through
 			  `g:{name}ModeInput` (see above).
 
+			- |v:count| and |v:count1| are provided through `g:{name}ModeCount`
+			  and `g:{name}ModeCount1` respectively.
+
 			*Error	you cannot pass a funcref to Lua from Vimscript!
 			      	- If you want to use a |funcref()| for {instruction}, it
 			      	  must be the name of the function as a `string`. >

--- a/doc/libmodal.txt
+++ b/doc/libmodal.txt
@@ -108,9 +108,9 @@ VARIABLES                                               *libmodal-usage-variable
 		|g:|    For more information about global variables.
 		|vim.g| For info about accessing |g:| from lua.
 
-                                                              *libmodal.Mode-vars*
-                                                             *libmodal.Mode.count*
-`Mode`.count
+MODE                                                          *libmodal.Mode-vars*
+
+`Mode`.count                                                   *libmodal.Mode.count*
 
 	The |v:count| of the mode.
 
@@ -126,9 +126,7 @@ VARIABLES                                               *libmodal-usage-variable
 			end,
 		})
 <
-
-                                                              *libmodal.Mode.exit*
-`Mode`.exit
+`Mode`.exit                                                     *libmodal.Mode.exit*
 
 	If `true`, flags the mode to exit. It will read this value before reading
 	the user's next key.
@@ -146,8 +144,7 @@ VARIABLES                                               *libmodal-usage-variable
 		})
 <
 
-                                                          *libmodal.Mode.timeouts*
-`Mode`.timeouts
+`Mode`.timeouts                                             *libmodal.Mode.timeouts*
 
 	The |libmodal-timeouts| configuration for this mode.
 
@@ -167,9 +164,10 @@ VARIABLES                                               *libmodal-usage-variable
 --------------------------------------------------------------------------------
 FUNCTIONS                                               *libmodal-usage-functions*
 
-                            *libmodal-mode* *libmodal#Enter()* *libmodal.mode.enter()*
-`libmodal.mode`.enter({name}, {instruction} [, {supress_exit}])
-`libmodal`#Enter({name}, {instruction} [, {supress_exit}])
+MODE                                                 *libmodal-mode* *libmodal.mode*
+
+`libmodal.mode`.enter({name}, {instruction} [, {supress_exit}])    *libmodal.mode.enter()*
+`libmodal`#Enter({name}, {instruction} [, {supress_exit}])              *libmodal#Enter()*
 
 	Enter a new |vim-mode| using {instruction} to determine what actions will
 	be taken upon specific user inputs.
@@ -264,8 +262,7 @@ FUNCTIONS                                               *libmodal-usage-function
 		|lua-eval|          For type conversions between Vimscript to |Lua|.
 		|libmodal-examples| For examples of this function.
 
-                                                          *libmodal.mode:switch()*
-`libmodal.mode`.switch(...)
+`libmodal.mode`.switch(...)                                 *libmodal.mode:switch()*
 
 	Convenience wrapper for |Mode:switch()|.
 
@@ -283,15 +280,14 @@ FUNCTIONS                                               *libmodal-usage-function
 		})
 <
 
-                                                            *libmodal.Mode:exit()*
-`libmodal.Mode`:exit()
+`libmodal.Mode`:exit()                                        *libmodal.Mode:exit()*
 
 	When the {instruction} parameter to |libmodal.mode.enter()| is a
 	|lua-table|, one can use |lua-function|s as mappings. When this is done, the
 	`self` parameter becomes available, and from this the `:exit()` function can
 	be called.
 
-	WARNING: this call will *not* interrupt |getchar()| (see |libmodal-mode|).
+	WARNING: this call will _not_ interrupt |getchar()| (see |libmodal-mode|).
 	         call `exit` only inside a `function` mapping as shown below.
 
 	Example: ~
@@ -303,8 +299,7 @@ FUNCTIONS                                               *libmodal-usage-function
 		})
 <
 
-                                                          *libmodal.Mode:switch()*
-`libmodal.Mode`:switch(...)
+`libmodal.Mode`:switch(...)                                 *libmodal.Mode:switch()*
 
 	|libmodal.mode.enter()| a new mode, and when it is finished, |Mode:exit()|
 	the current mode.
@@ -324,8 +319,9 @@ FUNCTIONS                                               *libmodal-usage-function
 			end,
 		})
 <
-                                                   *libmodal-layer* *libmodal.layer*
-`libmodal.layer`.enter({keymap} [, {exit_char}])            *libmodal.layer.enter()*
+LAYER                                              *libmodal-layer* *libmodal.layer*
+
+`libmodal.layer`.enter({keymap} [, {exit_char}])                *libmodal.layer.enter()*
 
 	While a |libmodal-mode| ignores behavior that has not been explicitly
 	defined, a |libmodal-layer| allows unrecognized |input| to be passed back
@@ -362,7 +358,7 @@ FUNCTIONS                                               *libmodal-usage-function
 		|libmodal-examples| For an example.
 		|vim.keymap.set()|  For more information about `opts`.
 
-`libmodal.layer`.new({keymap})                                *libmodal.layer.new()*
+`libmodal.layer`.new({keymap})                                  *libmodal.layer.new()*
 
 	See |libmodal.layer.enter()| for more information. This function only
 	differs from |libmodal.layer.enter()| in that instead of entering the layer
@@ -420,7 +416,7 @@ FUNCTIONS                                               *libmodal-usage-function
 		|libmodal.Layer:enter()| A shortcut to access this function.
 		|libmodal.Layer.exit()|   How to create a |libmodal.Layer|
 
-`libmodal.Layer`:map({mode}, {lhs}, {rhs}, {opts})            *libmodal.Layer:map()*
+`libmodal.Layer`:map({mode}, {lhs}, {rhs}, {opts})                    *libmodal.Layer:map()*
 
 	{mode}, {lhs}, {rhs}, and {opts} are the same as in |vim.keymap.set()|
 	except that a {mode} table is not supported.
@@ -429,7 +425,7 @@ FUNCTIONS                                               *libmodal-usage-function
 		|libmodal-examples| For an example.
 		|vim.keymap.set()|  For information about the args.
 
-`libmodal.Layer`:unmap({mode}, {lhs})                       *libmodal.Layer:unmap()*
+`libmodal.Layer`:unmap({mode}, {lhs})                           *libmodal.Layer:unmap()*
 
 	{mode} and {lhs} are the same as in |vim.keymap.del()| except that a {mode}
 	table is not supported.
@@ -440,9 +436,10 @@ FUNCTIONS                                               *libmodal-usage-function
 		|libmodal-examples| For an example.
 		|vim.keymap.del()|  For information about the args.
 
-                      *libmodal-prompt* *libmodal#Prompt()*  *libmodal.prompt.enter()*
-`libmodal.prompt`.enter({name}, {instruction} [, {completions}])
-`libmodal`#Prompt({name}, {instruction} [, {completions}])
+PROMPT                                           *libmodal-prompt* *libmodal.prompt*
+
+`libmodal.prompt`.enter({name}, {instruction} [, {completions}]) *libmodal.prompt.enter()*
+`libmodal`#Prompt({name}, {instruction} [, {completions}])             *libmodal#Prompt()*
 
 	Besides accepting user input like keys in |Normal-mode|, |libmodal| is
 	also capable of prompting the user for |input| like |Cmdline-mode|. To
@@ -513,22 +510,19 @@ FUNCTIONS                                               *libmodal-usage-function
 		|lua-eval|          For type conversions between Vimscript to |Lua|.
 		|libmodal-examples| For examples of this function.
 
-                                                                    *libmodal-Var*
-`Var`
+VAR                                                    *libmodal-Var* *libmodal.Var*
 
 	Some values mentioned above may be typed `libmodal-Var`. By default, `Var`s
 	mirror a specific |g:var|, but they may be given instance-local values as
 	well. In this case, the instance value is preferred to the global value.
 
-                                                              *libmodal.Var:get()*
-`Var`:get()
+`Var`:get()                                                     *libmodal.Var:get()*
 
 	Return: ~
 		|libmodal.Var:get_local()| if a local value exists, or
 		|libmodal.Var:get_global()|.
 
-                                                       *libmodal.Var:get_global()*
-`Var`:get_global()
+`Var`:get_global()                                       *libmodal.Var:get_global()*
 
 	Return: ~
 		The global value.
@@ -537,14 +531,12 @@ FUNCTIONS                                               *libmodal-usage-function
 		|g:|    For more information about global variables.
 		|vim.g| For info about accessing |g:| from lua.
 
-                                                        *libmodal.Var:get_local()*
-`Var`:get_local()
+`Var`:get_local()                                         *libmodal.Var:get_local()*
 
 	Return: ~
 		The local value.
 
-                                                              *libmodal.Var:set()*
-`Var`:set({value})
+`Var`:set({value})                                                *libmodal.Var:set()*
 
 	|libmodal.Var:set_local()| if a local value exists, otherwise
 	|libmodal.Var:set_global()|.
@@ -552,8 +544,7 @@ FUNCTIONS                                               *libmodal-usage-function
 	Parameters: ~
 		{value}  to set.
 
-                                                       *libmodal.Var:set_global()*
-`Var`:set_global({value})
+`Var`:set_global({value})                                  *libmodal.Var:set_global()*
 
 	Set a {value} locally.
 
@@ -564,8 +555,7 @@ FUNCTIONS                                               *libmodal-usage-function
 		|g:|    For more information about global variables.
 		|vim.g| For info about accessing |g:| from lua.
 
-                                                        *libmodal.Var:set_local()*
-`Var`:set_local()
+`Var`:set_local({value})                                  *libmodal.Var:set_local()*
 
 	Set a {value} globally.
 

--- a/doc/libmodal.txt
+++ b/doc/libmodal.txt
@@ -108,6 +108,70 @@ VARIABLES                                               *libmodal-usage-variable
 		|g:|    For more information about global variables.
 		|vim.g| For info about accessing |g:| from lua.
 
+                                                              *libmodal.Mode-vars*
+                                                             *libmodal.Mode.count*
+`Mode`.count
+
+	The |v:count| of the mode.
+
+	Type: ~
+		|libmodal-Var| of |lua-number|
+
+	Example: ~
+>lua
+		libmodal.mode.enter('Foo', {
+			G = function(self)
+				local count = self.count:get()
+				vim.api.nvim_command('norm! ' .. tostring(count) .. 'G')
+			end,
+		})
+<
+
+                                                            *libmodal.Mode.count1*
+`Mode`.count1
+
+	The |v:count1| equivalent of |libmodal.Mode.count|.
+
+	Type: ~
+		|libmodal-Var| of |lua-number|
+
+                                                              *libmodal.Mode.exit*
+`Mode`.exit
+
+	If `true`, flags the mode to exit. It will read this value before reading
+	the user's next key.
+
+	Type: ~
+		|libmodal-Var| of `boolean`
+
+	Example: ~
+>lua
+		libmodal.mode.enter('Foo', {
+			q = function(self)
+				vim.notify('Hello!')
+				self.exit:set_local(true)
+			end,
+		})
+<
+
+                                                          *libmodal.Mode.timeouts*
+`Mode`.timeouts
+
+	The |libmodal-timeouts| configuration for this mode.
+
+	Type: ~
+		|libmodal-Var| of `boolean`
+
+	Example: ~
+>lua
+		libmodal.mode.enter('Foo', {
+			t = function(self)
+				local timeouts = self.timeouts:get()
+				self.timeouts:set_local(not timeouts) -- toggle timeouts
+			end,
+		})
+<
+
 --------------------------------------------------------------------------------
 FUNCTIONS                                               *libmodal-usage-functions*
 
@@ -176,10 +240,12 @@ FUNCTIONS                                               *libmodal-usage-function
 <
 
 			NOTE: Some QoL features are available by default when
-			      specifying a `dict`/`table` value for {instruction} that
+			      specifying a `dict` / |lua-table| value for {instruction} that
 			      would otherwise have to be programmed manually if a
 			      `function` is specified.
 
+			      - Bound |lua-function|s may accept a `self` parameter, which
+					allows access to |libmodal.Mode-vars|.
 			      - A user's typed characters will show in the
 			        lower right corner when {instruction} is a table.
 			      - If `g:libmodalTimeouts` is enabled, then user input will be
@@ -449,6 +515,65 @@ FUNCTIONS                                               *libmodal-usage-function
 	See also: ~
 		|lua-eval|          For type conversions between Vimscript to |Lua|.
 		|libmodal-examples| For examples of this function.
+
+                                                                    *libmodal-Var*
+`Var`
+
+	Some values mentioned above may be typed `libmodal-Var`. By default, `Var`s
+	mirror a specific |g:var|, but they may be given instance-local values as
+	well. In this case, the instance value is preferred to the global value.
+
+                                                              *libmodal.Var:get()*
+`Var`:get()
+
+	Return: ~
+		|libmodal.Var:get_local()| if a local value exists, or
+		|libmodal.Var:get_global()|.
+
+                                                       *libmodal.Var:get_global()*
+`Var`:get_global()
+
+	Return: ~
+		The global value.
+
+	See also: ~
+		|g:|    For more information about global variables.
+		|vim.g| For info about accessing |g:| from lua.
+
+                                                        *libmodal.Var:get_local()*
+`Var`:get_local()
+
+	Return: ~
+		The local value.
+
+                                                              *libmodal.Var:set()*
+`Var`:set({value})
+
+	|libmodal.Var:set_local()| if a local value exists, otherwise
+	|libmodal.Var:set_global()|.
+
+	Parameters: ~
+		{value}  to set.
+
+                                                       *libmodal.Var:set_global()*
+`Var`:set_global({value})
+
+	Set a {value} locally.
+
+	Parameters: ~
+		{value}  to set globally.
+
+	See also: ~
+		|g:|    For more information about global variables.
+		|vim.g| For info about accessing |g:| from lua.
+
+                                                        *libmodal.Var:set_local()*
+`Var`:set_local()
+
+	Set a {value} globally.
+
+	Parameters: ~
+		{value}  to set locally.
 
 --------------------------------------------------------------------------------
 EVENTS                                                     *libmodal-usage-events*

--- a/examples/lua/keymaps-supress-exit.lua
+++ b/examples/lua/keymaps-supress-exit.lua
@@ -13,8 +13,11 @@ local fooModeKeymaps =
 {
 	[k '<Esc>'] = 'echom "You cant exit using escape."',
 	q = 'let g:fooModeExit = 1', -- exits all instances of this mode
+	w = function(self)
+		self.exit:set_global(true) -- exits all instances of the mode (with lua)
+	end,
 	x = function(self)
-		self:exit() -- exits this instance of the mode
+		self.exit:set_local(true) -- exits this instance of the mode
 	end,
 	y = function(self)
 		self:switch('Bar', barModeKeymaps) -- enters Bar and then exits Foo when it is done

--- a/examples/lua/keymaps.lua
+++ b/examples/lua/keymaps.lua
@@ -13,6 +13,10 @@ local fooModeKeymaps =
 	j = 'norm j',
 	k = 'norm k',
 	l = 'norm l',
+	G = function(self)
+		local count = self.count:get()
+		vim.api.nvim_command('norm! ' .. count .. 'G')
+	end,
 	zf = 'split',
 	zfc = 'q',
 	zff = split_twice,

--- a/examples/lua/vars.lua
+++ b/examples/lua/vars.lua
@@ -1,0 +1,79 @@
+--[[
+	This file demonstrates how `Var`s work in Modes and Prompts.
+]]
+
+--- WARN: do not import this in your code! it is not part of the public API.
+local Vars = require 'libmodal.utils.Vars'
+
+--- Check the value of the local var
+--- @param var any
+--- @param val unknown the value to check is equal to
+local function assert_local_eq(var, val)
+	assert(var:get_local() == val, 'assertion: the global value equals ' .. vim.inspect(val))
+end
+
+--- Check the value of the global var
+--- @param var any
+--- @param val unknown the value to check is equal to
+local function assert_global_eq(var, val)
+	assert(var:get_global() == val, 'assertion: the global value equals ' .. vim.inspect(val))
+end
+
+--- Check the value of the scoped var
+--- @param var any
+--- @param val unknown the value to check is equal to
+--- @param scope 'global'|'local'
+local function assert_eq(var, val, scope)
+	assert(var:get() == val, 'assertion: the value equals ' .. vim.inspect(val))
+	local fn = scope == 'local' and  assert_local_eq  or assert_global_eq
+	fn(var, val)
+end
+
+--- check the value of all vars
+--- @param var any
+--- @param val unknown the value to check is equal to
+local function assert_all_eq(var, val)
+	assert_eq(var, val, 'local')
+	assert_global_eq(var, val)
+end
+
+local mode_name = 'Foo'
+local var_name = 'Bar'
+
+--- WARN: do not use this function in your code! It is not part of the public API.
+local foo = Vars.new(mode_name, var_name)
+
+-- 1. baseline
+
+assert_all_eq(foo, nil)
+
+-- 2. without local value, `:get` and `:set` use globals
+
+local global_value = true
+
+foo:set(global_value)
+
+assert_eq(foo, global_value, 'global')
+assert_local_eq(foo, nil)
+
+-- 3. set local value
+
+foo:set_local(global_value)
+
+assert_all_eq(foo, global_value)
+
+-- 4. with local value, `:get` and `:set` use locals
+
+local local_value = false
+
+foo:set(local_value)
+
+assert_eq(foo, local_value, 'local')
+assert_global_eq(foo, global_value)
+
+-- Finally, unset all so the test can be run again
+
+foo:set_global(nil)
+foo:set_local(nil)
+
+assert_all_eq(foo, nil)

--- a/examples/lua/vars.lua
+++ b/examples/lua/vars.lua
@@ -3,7 +3,7 @@
 ]]
 
 --- WARN: do not import this in your code! it is not part of the public API.
-local Vars = require 'libmodal.utils.Vars'
+local Var = require 'libmodal.utils.Var'
 
 --- Check the value of the local var
 --- @param var any
@@ -41,7 +41,7 @@ local mode_name = 'Foo'
 local var_name = 'Bar'
 
 --- WARN: do not use this function in your code! It is not part of the public API.
-local foo = Vars.new(mode_name, var_name)
+local foo = Var.new(mode_name, var_name)
 
 -- 1. baseline
 

--- a/lua/libmodal/Mode.lua
+++ b/lua/libmodal/Mode.lua
@@ -15,7 +15,6 @@ local utils = require 'libmodal.utils' --- @type libmodal.utils
 --- @field private popups libmodal.collections.Stack
 --- @field private supress_exit boolean
 --- @field public count libmodal.utils.Var[number]
---- @field public count1 libmodal.utils.Var[number]
 --- @field public exit libmodal.utils.Var[boolean]
 --- @field public timeouts? libmodal.utils.Var[boolean]
 local Mode = utils.classes.new()
@@ -46,7 +45,6 @@ function Mode:execute_instruction(instruction)
 	end
 
 	self.count:set(0)
-	self.count1:set(1)
 	self:redraw_virtual_cursor()
 end
 
@@ -113,7 +111,6 @@ function Mode:enter()
 		self.popups:push(utils.Popup.new())
 	end
 
-	self.count1:set(1)
 	self.count:set(0)
 	self.exit:set(false)
 
@@ -166,7 +163,6 @@ function Mode:get_user_input()
 		local oldCount = self.count:get()
 		local newCount = tonumber(oldCount .. string.char(user_input))
 		self.count:set(newCount)
-		self.count1:set(math.max(1, newCount))
 	end
 
 	if not self.supress_exit and user_input == globals.ESC_NR then -- the user wants to exit.
@@ -260,7 +256,6 @@ function Mode.new(name, instruction, supress_exit)
 	local self = setmetatable(
 		{
 			count = utils.Var.new(name, 'count'),
-			count1 = utils.Var.new(name, 'count1'),
 			exit = utils.Var.new(name, 'exit'),
 			input = utils.Var.new(name, 'input'),
 			instruction = instruction,

--- a/lua/libmodal/Mode.lua
+++ b/lua/libmodal/Mode.lua
@@ -47,8 +47,8 @@ function Mode:execute_instruction(instruction)
 		vim.api.nvim_command(instruction)
 	end
 
-	self.count:set(0)
-	self.count1:set(1)
+	self.count:set_global(0)
+	self.count1:set_global(1)
 	self:redraw_virtual_cursor()
 end
 
@@ -61,7 +61,7 @@ function Mode:check_input_for_mapping()
 	self.flush_input_timer:stop()
 
 	-- append the latest input to the locally stored input history.
-	self.input_bytes[#self.input_bytes + 1] = self.global_input:get()
+	self.input_bytes[#self.input_bytes + 1] = self.global_input:get_global()
 
 	-- get the command based on the users input.
 	local cmd = self.mappings:get(self.input_bytes)
@@ -115,8 +115,8 @@ function Mode:enter()
 		self.popups:push(utils.Popup.new())
 	end
 
-	self.count:set(0)
-	self.count1:set(1)
+	self.count:set_global(0)
+	self.count1:set_global(1)
 
 	self.local_exit = false
 
@@ -162,7 +162,7 @@ end
 --- @private
 --- @return boolean `true` if the mode's exit was flagged
 function Mode:exit_flagged()
-	return self.local_exit or globals.is_true(self.global_exit:get())
+	return self.local_exit or globals.is_true(self.global_exit:get_global())
 end
 
 --- get input from the user.
@@ -185,13 +185,13 @@ function Mode:get_user_input()
 	end
 
 	-- set the global input variable to the new input.
-	self.global_input:set(user_input)
+	self.global_input:set_global(user_input)
 
 	if ZERO <= user_input and user_input <= NINE then
-		local oldCount = self.count:get()
+		local oldCount = self.count:get_global()
 		local newCount = tonumber(oldCount .. string.char(user_input))
-		self.count:set(newCount)
-		self.count1:set(math.max(1, newCount))
+		self.count:set_global(newCount)
+		self.count1:set_global(math.max(1, newCount))
 	end
 
 	if not self.supress_exit and user_input == globals.ESC_NR then -- the user wants to exit.
@@ -321,7 +321,7 @@ function Mode.new(name, instruction, supress_exit)
 		self.timeouts = utils.Vars.new('timeouts', self.name)
 
 		-- read the correct timeout variable.
-		self.timeouts_enabled = self.timeouts:get() or vim.g.libmodalTimeouts
+		self.timeouts_enabled = self.timeouts:get_global() or vim.g.libmodalTimeouts
 	end
 
 	return self

--- a/lua/libmodal/Mode.lua
+++ b/lua/libmodal/Mode.lua
@@ -5,6 +5,7 @@ local utils = require 'libmodal.utils' --- @type libmodal.utils
 --- @class libmodal.Mode
 --- @field private flush_input_timer unknown
 --- @field private help? libmodal.utils.Help
+--- @field private input libmodal.utils.Var[number]
 --- @field private input_bytes? number[] local `input` history
 --- @field private instruction fun()|{[string]: fun()|string}
 --- @field private mappings libmodal.collections.ParseTable
@@ -16,7 +17,6 @@ local utils = require 'libmodal.utils' --- @type libmodal.utils
 --- @field public count libmodal.utils.Var[number]
 --- @field public count1 libmodal.utils.Var[number]
 --- @field public exit libmodal.utils.Var[boolean]
---- @field public input libmodal.utils.Var[number]
 --- @field public timeouts? libmodal.utils.Var[boolean]
 local Mode = utils.classes.new()
 
@@ -139,7 +139,7 @@ function Mode:enter()
 			utils.notify_error('Error during nvim-libmodal mode', result)
 			self.exit:set_local(true)
 		end
-	until self.exit:get()
+	until globals.is_true(self.exit:get())
 
 	self:tear_down()
 	vim.api.nvim_exec_autocmds('ModeChanged', {pattern = self.name .. ':' .. previous_mode})

--- a/lua/libmodal/Mode.lua
+++ b/lua/libmodal/Mode.lua
@@ -13,11 +13,11 @@ local utils = require 'libmodal.utils' --- @type libmodal.utils
 --- @field private ns number the namespace where cursor highlights are drawn on
 --- @field private popups libmodal.collections.Stack
 --- @field private supress_exit boolean
---- @field public count libmodal.utils.Vars[number]
---- @field public count1 libmodal.utils.Vars[number]
---- @field public exit libmodal.utils.Vars[boolean]
---- @field public input libmodal.utils.Vars[number]
---- @field public timeouts? libmodal.utils.Vars[boolean]
+--- @field public count libmodal.utils.Var[number]
+--- @field public count1 libmodal.utils.Var[number]
+--- @field public exit libmodal.utils.Var[boolean]
+--- @field public input libmodal.utils.Var[number]
+--- @field public timeouts? libmodal.utils.Var[boolean]
 local Mode = utils.classes.new()
 
 local HELP_CHAR = '?'
@@ -259,10 +259,10 @@ function Mode.new(name, instruction, supress_exit)
 	-- inherit the metatable.
 	local self = setmetatable(
 		{
-			count = utils.Vars.new(name, 'count'),
-			count1 = utils.Vars.new(name, 'count1'),
-			exit = utils.Vars.new(name, 'exit'),
-			input = utils.Vars.new(name, 'input'),
+			count = utils.Var.new(name, 'count'),
+			count1 = utils.Var.new(name, 'count1'),
+			exit = utils.Var.new(name, 'exit'),
+			input = utils.Var.new(name, 'input'),
 			instruction = instruction,
 			name = name,
 			ns = vim.api.nvim_create_namespace('libmodal' .. name),
@@ -293,7 +293,7 @@ function Mode.new(name, instruction, supress_exit)
 		self.popups = require('libmodal.collections.Stack').new()
 
 		-- create a variable for whether or not timeouts are enabled.
-		self.timeouts = utils.Vars.new(self.name, 'timeouts', vim.g.libmodalTimeouts)
+		self.timeouts = utils.Var.new(self.name, 'timeouts', vim.g.libmodalTimeouts)
 	end
 
 	return self

--- a/lua/libmodal/Mode.lua
+++ b/lua/libmodal/Mode.lua
@@ -259,10 +259,10 @@ function Mode.new(name, instruction, supress_exit)
 	-- inherit the metatable.
 	local self = setmetatable(
 		{
-			count = utils.Vars.new('count', name),
-			count1 = utils.Vars.new('count1', name),
-			exit = utils.Vars.new('exit', name),
-			input = utils.Vars.new('input', name),
+			count = utils.Vars.new(name, 'count'),
+			count1 = utils.Vars.new(name, 'count1'),
+			exit = utils.Vars.new(name, 'exit'),
+			input = utils.Vars.new(name, 'input'),
 			instruction = instruction,
 			name = name,
 			ns = vim.api.nvim_create_namespace('libmodal' .. name),
@@ -293,7 +293,7 @@ function Mode.new(name, instruction, supress_exit)
 		self.popups = require('libmodal.collections.Stack').new()
 
 		-- create a variable for whether or not timeouts are enabled.
-		self.timeouts = utils.Vars.new('timeouts', self.name, vim.g.libmodalTimeouts)
+		self.timeouts = utils.Vars.new(self.name, 'timeouts', vim.g.libmodalTimeouts)
 	end
 
 	return self

--- a/lua/libmodal/Prompt.lua
+++ b/lua/libmodal/Prompt.lua
@@ -60,10 +60,10 @@ function Prompt:get_user_input()
 	--- @param user_input string
 	local function user_input_callback(user_input)
 		if user_input and user_input:len() > 0 then -- the user actually entered something.
-			self.input:set(user_input)
+			self.input:set_global(user_input)
 			self:execute_instruction(user_input)
 
-			local should_exit = self.exit:get()
+			local should_exit = self.exit:get_global()
 			if should_exit ~= nil then
 				continue_prompt = not should_exit
 			end

--- a/lua/libmodal/Prompt.lua
+++ b/lua/libmodal/Prompt.lua
@@ -113,9 +113,9 @@ function Prompt.new(name, instruction, user_completions)
 
 	local self = setmetatable(
 		{
-			exit = utils.Vars.new('exit', name),
+			exit = utils.Vars.new(name, 'exit'),
 			indicator = {hl = 'LibmodalStar', text = '* ' .. name .. ' > '},
-			input = utils.Vars.new('input', name),
+			input = utils.Vars.new(name, 'input'),
 			instruction = instruction,
 			name = name
 		},

--- a/lua/libmodal/Prompt.lua
+++ b/lua/libmodal/Prompt.lua
@@ -3,9 +3,9 @@ local utils = require 'libmodal.utils' --- @type libmodal.utils
 --- @class libmodal.Prompt
 --- @field private completions? string[]
 --- @field private indicator {hl: string, text: string}
---- @field private exit libmodal.utils.Vars
+--- @field private exit libmodal.utils.Var
 --- @field private help? libmodal.utils.Help
---- @field private input libmodal.utils.Vars
+--- @field private input libmodal.utils.Var
 --- @field private instruction fun()|{[string]: fun()|string}
 --- @field private name string
 local Prompt = utils.classes.new()
@@ -113,9 +113,9 @@ function Prompt.new(name, instruction, user_completions)
 
 	local self = setmetatable(
 		{
-			exit = utils.Vars.new(name, 'exit'),
+			exit = utils.Var.new(name, 'exit'),
 			indicator = {hl = 'LibmodalStar', text = '* ' .. name .. ' > '},
-			input = utils.Vars.new(name, 'input'),
+			input = utils.Var.new(name, 'input'),
 			instruction = instruction,
 			name = name
 		},

--- a/lua/libmodal/Prompt.lua
+++ b/lua/libmodal/Prompt.lua
@@ -60,10 +60,10 @@ function Prompt:get_user_input()
 	--- @param user_input string
 	local function user_input_callback(user_input)
 		if user_input and user_input:len() > 0 then -- the user actually entered something.
-			self.input:set_global(user_input)
+			self.input:set(user_input)
 			self:execute_instruction(user_input)
 
-			local should_exit = self.exit:get_global()
+			local should_exit = self.exit:get()
 			if should_exit ~= nil then
 				continue_prompt = not should_exit
 			end

--- a/lua/libmodal/utils/Var.lua
+++ b/lua/libmodal/utils/Var.lua
@@ -1,36 +1,36 @@
---- @class libmodal.utils.Vars
+--- @param str_with_spaces string
+--- @param first_letter_modifier fun(s: string): string
+local function no_spaces(str_with_spaces, first_letter_modifier)
+	local split_str = vim.split(str_with_spaces:gsub(vim.pesc '_', vim.pesc ' '), ' ')
+
+	--- @param str string
+	--- @param func fun(s: string): string
+	local function camel_case(str, func)
+		return func(str:sub(0, 1) or '') .. (str:sub(2) or ''):lower()
+	end
+
+	split_str[1] = camel_case(split_str[1], first_letter_modifier)
+
+	for i = 2, #split_str do split_str[i] =
+		camel_case(split_str[i], string.upper)
+	end
+
+	return table.concat(split_str)
+end
+
+--- @class libmodal.utils.Var
 --- @field private mode_name string the highlight group to use when printing `str`
 --- @field private value? unknown the local value of the variable
 --- @field private var_name string the highlight group to use when printing `str`
-local Vars = require('libmodal.utils.classes').new()
+local Var = require('libmodal.utils.classes').new()
 
 --- create a new set of variables
 --- @param mode_name string the name of the mode
---- @param var_name string the name of the key used to refer to this variable in `Vars`.
+--- @param var_name string the name of the key used to refer to this variable in `Var`.
 --- @param default_global? unknown the default global value
---- @return libmodal.utils.Vars
-function Vars.new(mode_name, var_name, default_global)
-	local self = setmetatable({}, Vars)
-
-	--- @param str_with_spaces string
-	--- @param first_letter_modifier fun(s: string): string
-	local function no_spaces(str_with_spaces, first_letter_modifier)
-		local split_str = vim.split(str_with_spaces:gsub(vim.pesc '_', vim.pesc ' '), ' ')
-
-		--- @param str string
-		--- @param func fun(s: string): string
-		local function camel_case(str, func)
-			return func(str:sub(0, 1) or '') .. (str:sub(2) or ''):lower()
-		end
-
-		split_str[1] = camel_case(split_str[1], first_letter_modifier)
-
-		for i = 2, #split_str do split_str[i] =
-			camel_case(split_str[i], string.upper)
-		end
-
-		return table.concat(split_str)
-	end
+--- @return libmodal.utils.Var
+function Var.new(mode_name, var_name, default_global)
+	local self = setmetatable({}, Var)
 
 	self.mode_name = no_spaces(mode_name, string.lower)
 	self.var_name  = 'Mode' .. no_spaces(var_name, string.upper)
@@ -45,7 +45,7 @@ end
 
 --- @generic T
 --- @return T value the local value if it exists, or the global value
-function Vars:get()
+function Var:get()
 	local local_value = self:get_local()
 	if local_value == nil then
 		return self:get_global()
@@ -56,18 +56,18 @@ end
 
 --- @generic T
 --- @return T global_value the global value
-function Vars:get_local()
+function Var:get_local()
 	return self.value
 end
 
 --- @generic T
 --- @return T global_value the global value
-function Vars:get_global()
+function Var:get_global()
 	return vim.g[self:name()]
 end
 
 --- @return string name the global Neovim setting
-function Vars:name()
+function Var:name()
 	return self.mode_name .. self.var_name
 end
 
@@ -76,7 +76,7 @@ end
 ---       too-eagerly shadow the global variable.
 --- @param val unknown set local value if it exists, or the global value
 --- @return nil
-function Vars:set(val)
+function Var:set(val)
 	if self:get_local() == nil then
 		self:set_global(val)
 	else
@@ -86,13 +86,13 @@ end
 
 --- @param val unknown set the local value equal to this
 --- @return nil
-function Vars:set_local(val)
+function Var:set_local(val)
 	self.value = val
 end
 
 --- @param val unknown set the global value equal to this
 --- @return nil
-function Vars:set_global(val)
+function Var:set_global(val)
 	if val == nil then
 		vim.api.nvim_del_var(self:name()) -- because `nvim_set_var('foo', nil)` actually sets 'foo' to `vim.NIL`
 	else
@@ -100,4 +100,4 @@ function Vars:set_global(val)
 	end
 end
 
-return Vars
+return Var

--- a/lua/libmodal/utils/Vars.lua
+++ b/lua/libmodal/utils/Vars.lua
@@ -5,11 +5,11 @@
 local Vars = require('libmodal.utils.classes').new()
 
 --- create a new set of variables
---- @param var_name string the name of the key used to refer to this variable in `Vars`.
 --- @param mode_name string the name of the mode
+--- @param var_name string the name of the key used to refer to this variable in `Vars`.
 --- @param default_global? unknown the default global value
 --- @return libmodal.utils.Vars
-function Vars.new(var_name, mode_name, default_global)
+function Vars.new(mode_name, var_name, default_global)
 	local self = setmetatable({}, Vars)
 
 	--- @param str_with_spaces string

--- a/lua/libmodal/utils/init.lua
+++ b/lua/libmodal/utils/init.lua
@@ -3,14 +3,14 @@
 --- @field classes libmodal.utils.classes
 --- @field Help libmodal.utils.Help
 --- @field Popup libmodal.utils.Popup
---- @field Vars libmodal.utils.Vars
+--- @field Var libmodal.utils.Var
 local utils =
 {
 	api = require 'libmodal.utils.api',
 	classes = require 'libmodal.utils.classes',
 	Help = require 'libmodal.utils.Help',
 	Popup = require 'libmodal.utils.Popup',
-	Vars  = require 'libmodal.utils.Vars',
+	Var  = require 'libmodal.utils.Var',
 }
 
 --- `vim.notify` with a `msg` some `error` which has a `vim.v.throwpoint` and `vim.v.exception`.


### PR DESCRIPTION
Closes #25

`v:count` can't be updated manually, so I've created an alternate facility which tracks count until commands are executed:

```lua
local my_mode = {
	g = function()
		vim.notify('count: ' .. vim.g.myModeModeCount)
	end
}

vim.keymap.set('n', 'M', function()
	require('libmodal').mode.enter('My mode', my_mode)
end)
```
