### PR TITLE
Fix handling of special keys

### DIFF
--- a/lua/libmodal/Mode.lua
+++ b/lua/libmodal/Mode.lua
@@ -293,7 +293,7 @@ function Mode:get_user_input()
 	-- set the global input variable to the new input.
 	self.input:set(user_input)
 
-	if ZERO <= user_input and user_input <= NINE then
+	if type(user_input) == "number" and ZERO <= user_input and user_input <= NINE then
 		local oldCount = self.count:get()
 		local newCount = tonumber(oldCount .. string.char(user_input))
 		self.count:set(newCount)


### PR DESCRIPTION
Check that the `user_input` is not a string before comparing it.