### PR TITLE
feat: mapping fallback

### DIFF
--- a/doc/libmodal.txt
+++ b/doc/libmodal.txt
@@ -166,25 +166,29 @@ FUNCTIONS                                               *libmodal-usage-function
 
 MODE                                                 *libmodal-mode* *libmodal.mode*
 
-`libmodal.mode`.enter({name}, {instruction} [, {supress_exit}])    *libmodal.mode.enter()*
-`libmodal`#Enter({name}, {instruction} [, {supress_exit}])              *libmodal#Enter()*
+`libmodal.mode`.enter(...)    *libmodal.mode.enter()*
+`libmodal`#Enter(...)              *libmodal#Enter()*
 
-	Enter a new |vim-mode| using {instruction} to determine what actions will
-	be taken upon specific user inputs.
+	Creates a mode (see |libmodal.mode.new()|) and then immediately enters it
+	(see |libmodal.Mode:enter()|).
 
-	User input is taken one character at a time using |getchar()|. It is
-	passed through a |g:var| determined by the {name} of the mode. For
-	example, if {name} is "FOO" then the |g:var| is `g:fooModeInput`.
-	Additionally, this input is reported as a |char2nr| number, and as such
-	should be decoded with `string.char()` (|nr2char| in |Lua|) if working
-	with raw characters is desired.
+	For additional notes on how a `Mode` works, see |libmodal.Mode:enter()|.
 
-	To take input on a line-by-line basis, see |libmodal-prompt|.
+	Parameters: ~
+		Same as |libmodal.mode.new()|
 
-	NOTE: mode transitions trigger |ModeChanged| events.
+	See also: ~
+		|libmodal-examples| For examples of this function.
+		|libmodal.mode.new| For an alternative that allows additional
+		                    customization before entering the mode.
 
-	NOTE: `libmodal.mode.enter()`/`libmodal#Enter()` may be called from inside
-	      itself. See |libmodal-examples| for an example.
+`libmodal.mode`.new({name}, {instruction} [, {supress_exit}])        *libmodal.mode.new()*
+
+	Create a new |vim-mode| using {instruction} to determine what actions will
+	be taken upon specific user inputs. To enter the mode use either
+	|libmodal.Mode:enter()| or |libmodal.mode.enter|.
+
+	For additional notes on how a mode works, see |libmodal.Mode:enter()|.
 
 	Parameters: ~
 		{name}         The name of the mode (e.g. |INSERT|).
@@ -258,9 +262,15 @@ MODE                                                 *libmodal-mode* *libmodal.m
 			  - use |libmodal.Mode:exit()|
 			  See |libmodal-examples|.
 
+	Return: ~
+		A `libmodal.Mode` object
+
 	See also: ~
-		|lua-eval|          For type conversions between Vimscript to |Lua|.
-		|libmodal-examples| For examples of this function.
+		|lua-eval|               For type conversions between Vimscript to |Lua|.
+		|libmodal-examples|      For examples of this function.
+		|libmodal.Mode:enter()|  For how to enter a mode using a `libmodal.Mode`
+		|libmodal.mode.enter|    For a convenient way to create and enter a
+		                         mode at once.
 
 `libmodal.mode.map`.fn({f}, ...)                              *libmodal.mode.map.fn()*
 
@@ -318,6 +328,33 @@ MODE                                                 *libmodal-mode* *libmodal.m
 		})
 <
 
+`libmodal.Mode`:enter()                                      *libmodal.Mode:enter()*
+
+	Enters the given mode.
+
+	While the mode is entered, user input is taken one character at a time using
+	|getchar()|. It is passed through a |g:var| determined by the {name} of the
+	mode. For example, if {name} is "FOO" then the |g:var| is `g:fooModeInput`.
+	Additionally, this input is reported as a |char2nr| number, and as such
+	should be decoded with `string.char()` (|nr2char| in |Lua|) if working
+	with raw characters is desired.
+
+	To take input on a line-by-line basis, see |libmodal-prompt|.
+
+	NOTE: mode transitions trigger |ModeChanged| events.
+
+	NOTE: `libmodal.mode.enter()`/`libmodal#Enter()` may be called from inside
+	      itself. See |libmodal-examples| for an example.
+
+	WARN: this function should not be called again while the mode is active!
+		  Either use |libmodal.mode.enter()| or create a new mode with
+		  |libmodal.mode.new()| and enter that instead.
+
+	See also: ~
+		|libmodal.mode.enter()|  For a helper to create and enter a function at
+		                         once.
+		|libmodal.mode.new()|    For how to create a `Mode`.
+
 `libmodal.Mode`:exit()                                        *libmodal.Mode:exit()*
 
 	When the {instruction} parameter to |libmodal.mode.enter()| is a
@@ -356,6 +393,30 @@ MODE                                                 *libmodal-mode* *libmodal.m
 				})
 			end,
 		})
+<
+
+`libmodal.Mode`:with_fallback({f})                     *libmodal.Mode:with_fallback()*
+
+	Set a fallback for the `Mode` such that when keys are entered by a user and
+	no mapping is defined for them, this function will be called.
+
+	Parameters: ~
+		{f}  a |lua-function| with the signature
+		   `fun(mode: libmodal.Mode, keys: string)`
+
+	Return: ~
+		- The same `libmodal.Mode`, but with the fallback applied. The return
+		  value can be safely ignored, as the fallback is applied even without
+		  variable reassignment.
+
+	Example: ~
+>lua
+	libmodal.mode
+		.new('FOO', {--[[your keymaps here]]})
+		:with_fallback(function (_, keys)
+			vim.notify(vim.inspect(keys))
+		end)
+		:enter()
 <
 LAYER                                              *libmodal-layer* *libmodal.layer*
 

--- a/doc/libmodal.txt
+++ b/doc/libmodal.txt
@@ -380,7 +380,9 @@ MODE                                                 *libmodal-mode* *libmodal.m
 	the current mode.
 
 	Parameters: ~
-		See |libmodal.mode.enter()|.
+		Either:
+		- A `libmodal.Mode` to enter
+		- Parameters to |libmodal.mode.new()|.
 
 	Example: ~
 >lua

--- a/examples/lua/keymaps-supress-exit.lua
+++ b/examples/lua/keymaps-supress-exit.lua
@@ -12,6 +12,9 @@ local barModeKeymaps = {
 local fooModeKeymaps =
 {
 	[k '<Esc>'] = 'echom "You cant exit using escape."',
+	h = function(self)
+		self:switch(libmodal.mode.new('Bar', barModeKeymaps)) -- enters Bar and then exits Foo when it is done
+	end,
 	q = 'let g:fooModeExit = 1', -- exits all instances of this mode
 	w = function(self)
 		self.exit:set_global(true) -- exits all instances of the mode (with lua)

--- a/examples/lua/keymaps.lua
+++ b/examples/lua/keymaps.lua
@@ -38,8 +38,16 @@ local id = vim.api.nvim_create_autocmd(
 	{ callback = function(ev) vim.notify(vim.inspect(ev)) end }
 )
 
--- enter the mode using the keymaps
-libmodal.mode.enter('FOO', fooModeKeymaps)
+local mode =
+	-- create a mode from the keymaps
+	libmodal.mode.new('FOO', fooModeKeymaps)
+	-- OPTIONAL: assign a fallback for the mode
+	:with_fallback(function (_, keys)
+		vim.notify(vim.inspect(keys))
+	end)
+
+-- enter the mode
+mode:enter()
 
 -- remove setup
 vim.api.nvim_del_autocmd(id)

--- a/lua/libmodal/Mode.lua
+++ b/lua/libmodal/Mode.lua
@@ -364,7 +364,13 @@ end
 --- @see libmodal.Mode.enter which `...` shares the layout of
 --- @see libmodal.Mode.exit
 function Mode:switch(...)
-	local mode = Mode.new(...)
+	local mode
+	if type(...) == 'table' then
+		mode = ...
+	else
+		mode = Mode.new(...)
+	end
+
 	mode:enter()
 	self.exit:set_local(true)
 end

--- a/lua/libmodal/init.lua
+++ b/lua/libmodal/init.lua
@@ -40,7 +40,7 @@ end
 --- @param keymap table the keymaps (e.g. `{n = {gg = {rhs = 'G', silent = true}}}`)
 --- @return libmodal.Layer
 function libmodal.layer.new(keymap)
-		return require('libmodal.Layer').new(keymap)
+	return require('libmodal.Layer').new(keymap)
 end
 
 libmodal.mode = {}

--- a/lua/libmodal/init.lua
+++ b/lua/libmodal/init.lua
@@ -46,11 +46,18 @@ end
 libmodal.mode = {}
 
 --- enter a mode.
+--- @param ... any arguments to `libmodal.mode.new`
+function libmodal.mode.enter(...)
+	local mode = libmodal.mode.new(...)
+	mode:enter()
+end
+
+--- create a new mode
 --- @param name string the name of the mode.
 --- @param instruction fun()|string|table a Lua function, keymap dictionary, Vimscript command.
-function libmodal.mode.enter(name, instruction, supress_exit)
-	local mode = require('libmodal.Mode').new(name, instruction, supress_exit)
-	mode:enter()
+--- @return libmodal.Mode
+function libmodal.mode.new(name, instruction, supress_exit)
+	return require('libmodal.Mode').new(name, instruction, supress_exit)
 end
 
 --- @see libmodal.mode.map.switch


### PR DESCRIPTION
This PR implements the ability to set a fallback for keymaps in a Mode. Here is an example:

```lua
libmodal.mode
	.new('FOO', {--[[your keymaps here]]})
	:with_fallback(function (_, keys)
		vim.notify(vim.inspect(keys))
	end)
	:enter()
```

Closes #39 